### PR TITLE
Push docker images in CD style

### DIFF
--- a/scripts/push.sh
+++ b/scripts/push.sh
@@ -40,12 +40,9 @@ tag_and_push_all() {
     done;
 }
 
-# Always push commit
-tag_and_push_all $COMMIT
-
 # Push snapshot when in master
-if [ "$TRAVIS_BRANCH" == "master" ]; then
-    tag_and_push_all snapshot
+if [ "$TRAVIS_BRANCH" == "master" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
+    tag_and_push_all master-${COMMIT:0:8}
 fi;
 
 # Push tag and latest when tagged


### PR DESCRIPTION
- removed the line that pushes for any commit
- changed Docker tag for pushes from the master branch. The pushed
  Docker tag now contains tag of form: "master-<8 char commit SHA>"
- the tag pusing remains the same.

Related to https://github.com/microservices-demo/microservices-demo/issues/553