### PR TITLE
change maven jdk version from 11 to 8

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -24,7 +24,7 @@ else
 fi
 CODE_DIR=$(cd $SCRIPT_DIR/..; pwd)
 echo $CODE_DIR
-$DOCKER_CMD run --rm -v $HOME/.m2:/root/.m2 -v $CODE_DIR:/usr/src/mymaven -w /usr/src/mymaven maven:3.6-jdk-11 mvn -q -DskipTests package
+$DOCKER_CMD run --rm -v $HOME/.m2:/root/.m2 -v $CODE_DIR:/usr/src/mymaven -w /usr/src/mymaven maven:3.6-jdk-8 mvn -q -DskipTests package
 
 cp $CODE_DIR/target/*.jar $CODE_DIR/docker/carts
 


### PR DESCRIPTION
when i use maven:3.6-jdk-11 it show 

[ERROR] Failed to execute goal on project carts: Could not resolve dependencies for project works.weave.microservices-demo:carts:jar:2.0.4.RELEASE: Could not find artifact org.openjfx:javafx.base:jar:11.0.0-SNAPSHOT in huaweicloud (https://repo.huaweicloud.com/repository/maven/) -> [Help 1]
[ERROR]
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR]
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/DependencyResolutionException

change jdk version to 8 to fix it.